### PR TITLE
DEV-15833 Setting content length before writing content to output str…

### DIFF
--- a/java/servlet/src/main/java/com/acrolinx/proxy/AcrolinxProxyServlet.java
+++ b/java/servlet/src/main/java/com/acrolinx/proxy/AcrolinxProxyServlet.java
@@ -205,6 +205,7 @@ public class AcrolinxProxyServlet extends HttpServlet
     {
         httpMethod.setURI(targetURL);
         setRequestHeader(httpMethod, "User-Agent", "Acrolinx Proxy");
+        setRequestHeader(httpMethod, "Host", targetURL.getHost());
     }
 
     private static void setRequestHeader(final HttpRequestBase httpMethod, final String headerName,


### PR DESCRIPTION
Hi Ralf, Hi Paresh

We were facing some issues with conten length in Java Proxy as reported in DEV-15833

1. Content length was set after writing response to output stream. This caused a BAD STRING or truncated string in the output.
Used Entity.getContentLength to get the length and set it in resp object.

2. Added doPut method to proxy

Please review the code changes and share your suggestions.
