### PR TITLE
Remove deprecated reviewers Dependabot config option

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,11 +4,7 @@ updates:
     directory: "/"
     schedule:
       interval: "daily"
-    reviewers:
-      - /acrolinx/integrationdevs-java
   - package-ecosystem: "maven"
     directory: "/"
     schedule:
       interval: "daily"
-    reviewers:
-      - /acrolinx/integrationdevs-java


### PR DESCRIPTION
See https://github.blog/changelog/2025-04-29-dependabot-reviewers-configuration-option-being-replaced-by-code-owners/